### PR TITLE
added success_codes[0,3010] to windows_package resources

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,7 @@ if platform?('windows')
         source node['ms_dotnet45']['http_url']
         installer_type :custom
         options '/quiet /norestart'
+        success_codes [0, 3010]
         timeout node['ms_dotnet45']['timeout']
         action :install
       end


### PR DESCRIPTION
3010 is returned as errorlevel in win2008 R2, which means SUCCESS but reboot required.
For some unknown reason, in Windows 2008 R2, the system returns this message even if /norestart options is given. 

You can see https://msdn.microsoft.com/en-us/library/windows/desktop/aa376931(v=vs.85).aspx for more info about 3010 result code. 